### PR TITLE
fix: support .qvnotebook file

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -12,7 +12,9 @@ export function openImportDialog() {
   return dialog.showOpenDialog({
     title: "Open Quiver Notebook",
     properties: ["openFile"],
-    filters: [{ name: "Quiver Library", extensions: ["qvlibrary"] }],
+    filters: [
+      { name: "Quiver Library", extensions: ["qvlibrary", "qvnotebook"] }
+    ],
     defaultPath: app.getPath("home")
   });
 }
@@ -20,21 +22,29 @@ export function openImportDialog() {
 export async function importNotebooksFromQuiverLibrary(files) {
   if (files.length !== 1) {
     inkdrop.notifications.addError("invalid file is selected.", {
-      detail: e.stack,
       dismissable: true
     });
     return;
   }
 
   const library = files[0];
-  const notebooks = fs
-    .readdirSync(library)
-    .filter(path => path.indexOf("qvnotebook") !== -1); // ignore mata.json for qvlibrary
+  const readNotebooks = (library) => {
+    const ext = path.extname(library);
+    if (ext === ".qvnotebook") {
+      return [library];
+    } else if (ext === ".qvlibrary") {
+      return fs
+        .readdirSync(library)
+        .filter(filePath => filePath.indexOf("qvnotebook") !== -1) // ignore mata.json for qvlibrary
+        .map(filePath => path.resolve(library, filePath)); // convert to absolute path
+    }
+    throw new Error("Unknown file extension: " + filePath);
+  }
 
+  const notebooks = readNotebooks(library);
   try {
-    await notebooks.forEach(async notebook => {
-      console.log(`processing notebook ${notebook}`);
-      const notebookPath = path.join(library, notebook);
+    await notebooks.forEach(async notebookPath => {
+      console.log(`processing notebook ${notebookPath}`);
       await importDocumentsFromQuiverNotebook(notebookPath);
     });
   } catch (e) {


### PR DESCRIPTION
Quiver can export a single `.qvnotebook` file.
Also "Shared Notebooks" is not parts of `.qvlibrary` file. Its just `.qvnotebook` file

So, I want to suppot `.qvnotebook` for importing.

## Test Plan

- [x] can import `example.qvnotebook`
- [x] can import `exmaple.qvlibrary`

I've tested this plugin and its success to import all my notebooks(3000+)!